### PR TITLE
feature(regions): Adding support for limiting the regions we query

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Usage of ./spot-price-exporter:
         Comma separated list of AWS partitions. Accepted values: aws, aws-cn, aws-us-gov (default "aws")
   -product-descriptions string
         Comma separated list of product descriptions. Accepted values: Linux/UNIX, SUSE Linux, Windows, Linux/UNIX (Amazon VPC), SUSE Linux (Amazon VPC), Windows (Amazon VPC) (default "Linux/UNIX")
+  -regions string
+        Comma separated list of AWS regions to get pricing for (defaults to *all*)
 ```
 
 ### Example metrics

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	rawLevel            = flag.String("log-level", "info", "log level")
 	partitions          = flag.String("partitions", "aws", "Comma separated list of AWS partitions. Accepted values: aws, aws-cn, aws-us-gov")
 	productDescriptions = flag.String("product-descriptions", "Linux/UNIX", "Comma separated list of product descriptions. Accepted values: Linux/UNIX, SUSE Linux, Windows, Linux/UNIX (Amazon VPC), SUSE Linux (Amazon VPC), Windows (Amazon VPC)")
+	regions = flag.String("regions", "", "Comma separated list of AWS regions to get pricing for (defaults to *all*)")
 )
 
 func init() {
@@ -34,9 +35,10 @@ func main() {
 	log.Infof("Starting AWS Spot Price exporter. [log-level=%s, partitions=%s, product-descriptions=%s]", *rawLevel, *partitions, *productDescriptions)
 	parts := splitAndTrim(*partitions)
 	pds := splitAndTrim(*productDescriptions)
+	regions := splitAndTrim(*regions)
 	validatePartitions(parts)
 	validateProductDesc(pds)
-	exporter, err := exporter.NewExporter(parts, pds)
+	exporter, err := exporter.NewExporter(parts, pds, regions)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
I don't run multi region, so data for anywhere but $REGION_OF_CHOICE is a waste
of prometheus resources.

This commit adds a `-regions` flag, comma-separated values, of which regions
we should be querying. eg,

```
-regions=us-east-1,eu-central-1
```