### PR TITLE
docs: Mention the docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Building the project is as simple as running a go build command. The result is a
 make build
 ```
 
+#### Docker
+
+An auto-built image is available at https://hub.docker.com/r/banzaicloud/spot-price-exporter/
+
+```
+docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY banzaicloud/spot-price-exporter
+```
+
 ### Run as dev
 ```
 export AWS_ACCESS_KEY_ID=""


### PR DESCRIPTION
I shamelessly went through all the of pagination of the docker images of banzaicloud, instead of just trying the name directly. Might as well mention there is a docker image, and it's URL.